### PR TITLE
Update dependency to Eureka Version 3.0.0

### DIFF
--- a/RxEureka.podspec
+++ b/RxEureka.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'RxEureka/Classes/**/*'
 
-  s.dependency 'Eureka'
+  s.dependency 'Eureka', '~> 3.0.0'
   s.dependency 'RxCocoa', '~> 3.0'
 
 end

--- a/RxEureka.podspec
+++ b/RxEureka.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'RxEureka/Classes/**/*'
 
-  s.dependency 'Eureka', '~> 2.0.0-beta.1'
+  s.dependency 'Eureka'
   s.dependency 'RxCocoa', '~> 3.0'
 
 end


### PR DESCRIPTION
There are no codebreaking changes in Eureka 2.0.1 -> 3.0.0.

Eureka 3.0.0 is needed to work with Swift 3.2 and Xcode 9.